### PR TITLE
Fix test that fails with App::Cmd 0.328

### DIFF
--- a/lib/MooseX/App/Cmd.pm
+++ b/lib/MooseX/App/Cmd.pm
@@ -19,9 +19,9 @@ sub BUILDARGS {
 sub BUILD {
     my $self  = shift;
     my $class = blessed $self;
-    $self->{arg0}      = File::Basename::basename($PROGRAM_NAME);
-    $self->{command}   = $class->_command( {} );
-    $self->{full_arg0} = $PROGRAM_NAME;
+    $self->{arg0}         = File::Basename::basename($PROGRAM_NAME);
+    $self->{command}      = $class->_command( {} );
+    $self->{full_arg0}    = $PROGRAM_NAME;
     $self->{show_version} = 0;
     return;
 }

--- a/lib/MooseX/App/Cmd.pm
+++ b/lib/MooseX/App/Cmd.pm
@@ -22,6 +22,7 @@ sub BUILD {
     $self->{arg0}      = File::Basename::basename($PROGRAM_NAME);
     $self->{command}   = $class->_command( {} );
     $self->{full_arg0} = $PROGRAM_NAME;
+    $self->{show_version} = 0;
     return;
 }
 


### PR DESCRIPTION
In App::Cmd 0.328, the default value for `$self->{show_version}` changed from undef to 0. This causes `t/build_emulates_new.t` to fail, because it expects the object internals to match.

Updates the BUILD method to explicitly set show_version to match the App::Cmd default.
